### PR TITLE
Clean css containers

### DIFF
--- a/app/assets/stylesheets/components/_card.scss
+++ b/app/assets/stylesheets/components/_card.scss
@@ -73,9 +73,9 @@
   transform: scale(1.1);
 }
 
-.container {
-  padding-top: 30px;
-}
+// .container {
+//   padding-top: 30px;
+// }
 
 .card-product {
   overflow: hidden;

--- a/app/assets/stylesheets/config/_fonts.scss
+++ b/app/assets/stylesheets/config/_fonts.scss
@@ -19,8 +19,6 @@ $logo-font: "Leckerli One", "Helvetica", "sans-serif";
 // }
 // $my-font: "Font Name";
 
-
-
 .logo {
   font-family: 'Leckerli One', cursive;
   font-size: 45px;
@@ -54,6 +52,13 @@ $logo-font: "Leckerli One", "Helvetica", "sans-serif";
   font-weight:bold;
 }
 
+.h2-show-allivu {
+  font-family: 'Roboto', bold;
+  font-size: 24px;
+  color: $allivugray;
+  font-weight: bold;
+}
+
 .h3-allivu {
   font-family: 'Roboto', bold;
   font-size: 24px;
@@ -84,6 +89,8 @@ $logo-font: "Leckerli One", "Helvetica", "sans-serif";
 .allivu-overblue {
   color: $allivublue;
   text-decoration: none;
+  font-size: 22px;
+  font-weight: 400;
 }
 
 #link-allivu-categories {

--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -1,10 +1,6 @@
 // Specific CSS for your home-page
-
-
 .row {
-  text-align: center;
   justify-content: space-between;
-
 }
 
 .home-scroll {
@@ -67,21 +63,6 @@
   }
 }
 
-// h3 {
-//   font-size: 20px;
-// }
-
-
-// .logo {
-//   font-size: 100px;
-//   margin-top: 20px;
-// }
-// p {
-//   font-weight: bolder;
-//   font-family: 'Raleway', sans-serif;
-//   margin-bottom: -10px;
-//   font-size: 18px;
-// }
 .banner {
   min-width: 100%;
   height: 150px;

--- a/app/views/bookings/edit.html.erb
+++ b/app/views/bookings/edit.html.erb
@@ -1,4 +1,1 @@
-<div class="container px-4">
-  <h1 class="h1-allivu"><strong>Edit your booking</strong></h5>
   <%= render "shared/edit_booking_form" %>
-</div>

--- a/app/views/services/_image_carousel.html.erb
+++ b/app/views/services/_image_carousel.html.erb
@@ -1,0 +1,31 @@
+<div id="service-gallery" class="carousel slide" data-ride="carousel">
+  <ol class="carousel-indicators">
+    <li data-target="#service-gallery" data-slide-to="0" class="active"></li>
+    <li data-target="#service-gallery" data-slide-to="1"></li>
+    <li data-target="#service-gallery" data-slide-to="2"></li>
+  </ol>
+
+  <div class="carousel-inner">
+    <div class="carousel-item active">
+      <% if @service.photos.any? %>
+        <div class="d-block w-100"></div><%=cl_image_tag @service.photos.first.key, height: 300, width: 400, crop: :fill %>
+      <% end %>
+    </div>
+
+   <% @service.photos.drop(1).each do |photo| %>
+      <div class="carousel-item">
+        <div class="d-block w-100"><%= cl_image_tag photo.key, height: 300, width: 400, crop: :fill %></div>
+      </div>
+    <% end %>
+  </div>
+
+  <a class="carousel-control-prev" href="#service-gallery" role="button" data-slide="prev">
+    <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+    <span class="sr-only">Previous</span>
+  </a>
+
+  <a class="carousel-control-next" href="#service-gallery" role="button" data-slide="next">
+    <span class="carousel-control-next-icon" aria-hidden="true"></span>
+    <span class="sr-only">Next</span>
+  </a>
+</div>

--- a/app/views/services/edit.html.erb
+++ b/app/views/services/edit.html.erb
@@ -1,4 +1,1 @@
-<div class="container">
-  <h1>Edit service</h1>
-  <%= render "shared/edit_service_form" %>
-</div>
+<%= render "shared/edit_service_form" %>

--- a/app/views/services/new.html.erb
+++ b/app/views/services/new.html.erb
@@ -1,12 +1,12 @@
-<div class="container">
-  <h2>Add your first Service</h2>
+<div class="container p-5">
+  <h1 class="h1-allivu pb-4">Add your first Service</h1>
   <%= simple_form_for(@service) do |f| %>
     <%= f.input :name, label: "What is the name of your service?" %>
     <%= f.input :category, collection: Service::CATEGORIES, label: "What type of service is it?"%>
     <%= f.input :description, label: "Describe your service in detail" %>
     <%= f.input :price, label: "Set a price (per day)" %>
     <%= f.input :location, label: "Where is your service located?" %>
-    <%= f.input :photos, as: :file, input_html: { multiple: true }, label: "Add photos of your service" %>
+    <%= f.input :photos, as: :file, input_html: { multiple: true }, label: "Add photos" %>
     <%= f.submit "Finish" %>
   <% end %>
 </div>

--- a/app/views/services/show.html.erb
+++ b/app/views/services/show.html.erb
@@ -1,47 +1,24 @@
 <%= render 'shared/navbar_pages' %>
 <!-- Hero Image Section Start-->
-<div id="carouselExampleControls" class="carousel slide" data-ride="carousel">
-    <div class="carousel-inner">
-      <div class="carousel-item active">
-      <% if @service.photos.any? %>
-        <%=cl_image_tag @service.photos.first.key, height: 300, width: 400, crop: :fill %>
-      </div>
-        <% @service.photos.drop(1).each do |photo| %>
-          <div class="carousel-item">
-            <%= cl_image_tag photo.key, height: 300, width: 400, crop: :fill %>
-          </div>
-        <% end %>
-      <% end %>
-    </div>
-    <a class="carousel-control-prev" href="#carouselExampleControls" role="button" data-slide="prev">
-      <span class="carousel-control-prev-icon" aria-hidden="true"></span>
-      <span class="sr-only">Previous</span>
-    </a>
-    <a class="carousel-control-next" href="#carouselExampleControls" role="button" data-slide="next">
-      <span class="carousel-control-next-icon" aria-hidden="true"></span>
-      <span class="sr-only">Next</span>
-    </a>
-  </div>
+<%= render 'image_carousel' %>
 
   <!-- Hero Image Section End-->
 
-  <div class="container px-4">
+  <div class="container px-3">
   <!-- Service info Start-->
-    <div class="row g-4 justify-content-center">
+    <div class="row g-4 px-3 justify-content-center">
       <div class="col-lg-8">
         <!-- Description-head Start-->
         <div class="service-head">
           <div class="service-head-details">
-            <h2 class="allivu-h2"><strong><%= @service.name.capitalize %></strong></h2>
-            <h3 class="allivu-h3">$<%= @service.price.to_i %></h3>
+            <h2 class="h2-show-allivu"><%= @service.name.capitalize %></h2>
+            <h3 class="allivu-overblue">€<%= @service.price.to_i %></h3>
           </div>
-            <h5>Service hosted by <%= "#{@service.user.first_name.capitalize} #{@service.user.last_name.capitalize}" %> </h5>
-            <h6><%= "#{@service.reviews.count} reviews" %></h6>
+            <p class="p-allivu-sm">By <%= "#{@service.user.first_name.capitalize} #{@service.user.last_name.capitalize}" %> </h5>
+            <p class="link-allivu"><%= "#{@service.reviews.count} reviews" %></h6>
         </div>
-        <hr>
 
-
-
+        <!-- Favorites Start-->
         <%if @favorite_services.include?(@service)%>
           <%= button_to service_favorite_path(@service, @favorite), method: :delete do%>
             <i class="bi bi-heart-fill"></i>
@@ -53,11 +30,7 @@
           <% end %>
         <% end %>
 
-
-
-
-
-        <div>
+      <div>
         <!-- Description-body Start-->
           <div class="row justify-content-center pb-4">
             <button class="button-wide"><strong>Check availability</strong></button>
@@ -115,8 +88,8 @@
   <!-- Review section End-->
   <!-- Provider about start-->
         <h5 class="p-allivu">About <%= "#{@service.user.first_name.capitalize} #{@service.user.last_name.capitalize}" %> </h5>
-        <% d = @service.created_at %>
-        <p>Joined in <%= "#{d.strftime("%B")} #{d.year}" %> </p>
+        <% date = @service.created_at %>
+        <p>Joined in <%= "#{date.strftime("%B")} #{date.year}" %> </p>
   <!-- Provider review start-->
         <% sum = [] %>
         <% @service.user.services.each do |serve| %>

--- a/app/views/shared/_edit_booking_form.html.erb
+++ b/app/views/shared/_edit_booking_form.html.erb
@@ -1,5 +1,10 @@
-<%= simple_form_for [@service, @booking] do |f| %>
-  <%= f.input :start_date, as: :date, html5: true %>
-  <%= f.input :end_date, as: :date, html5: true %>
-  <%= f.submit "Update" %>
-<% end %>
+<div class="container-fluid pt-5 d-flex flex-column align-items-center">
+  <h1 class="h1-allivu py-4"><strong>Edit your booking</strong></h1>
+  <div class="py-1">
+    <%= simple_form_for [@service, @booking] do |f| %>
+      <%= f.input :start_date, as: :date, html5: true %>
+      <%= f.input :end_date, as: :date, html5: true %>
+      <%= f.submit "Update" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/shared/_edit_service_form.html.erb
+++ b/app/views/shared/_edit_service_form.html.erb
@@ -1,8 +1,13 @@
- <%= simple_form_for @service do |f| %>
-    <%= f.input :name, html5: true %>
-    <%= f.input :category, html5: true %>
-    <%= f.input :price, html5: true %>
-    <%= f.input :description, html5: true %>
-    <%= f.input :location, html5: true %>
-    <%= f.submit "Update" %>
-  <% end %>
+<div class="container p-4">
+  <h1 class="my-5">Edit service</h1>
+  <div class="mt-3">
+    <%= simple_form_for @service do |f| %>
+      <%= f.input :name, html5: true %>
+      <%= f.input :category, html5: true %>
+      <%= f.input :price, html5: true %>
+      <%= f.input :description, html5: true %>
+      <%= f.input :location, html5: true %>
+      <%= f.submit "Update" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/shared/_navbar_bottom.html.erb
+++ b/app/views/shared/_navbar_bottom.html.erb
@@ -1,6 +1,6 @@
 
 <nav class="fixed-bottom navbar-lewagon">
-    <div class="row">
+    <div class="row text-center">
         <div class="col">
           <%= link_to root_path do %>
             <i class="fa-solid fa-house icone-navbaractive"></i>


### PR DESCRIPTION
- Removed padding from containers that would leave a big gap on the top.
- Tweaked `.allivu-overblue` font style
- Prevented `navbar_bottom` from breaking
- Reviewed **EVERY SINGLE .HTML FILE** that contained a `.container` class to see how it would be affected.

See images below for example:
![Screenshot 2022-09-06 at 9 53 26 PM](https://user
![Screenshot 2022-09-06 at 9 56 27 PM](https://user-images.githubusercontent.com/105768950/188736876-67a7dbc1-8ce8-4c88-8a1c-cec931688f3e.png)
-images.githubusercontent.com/105768950/188736728-560133f5-0a26-4f98-ad0a-f1cbf4fe2e70.png)
![Screenshot 2022-09-06 at 9 56 30 PM](https://user-images.githubusercontent.com/105768950/188736883-3086a1e1-f60e-495a-b3aa-140da6a7474d.png)

![Screenshot 2022-09-06 at 9 53 26 PM](https://user-images.githubusercontent.com/105768950/188736855-fa80d5ac-3411-4861-8a97-4ad90daed497.png)
![Screenshot 2022-09-06 at 9 53 33 PM](https://user-images.githubusercontent.com/105768950/188736869-6ed032c8-2ebc-4c32-aa6c-fe97fdd7ffe2.png)



