### PR TITLE
Remove authentication for services#show

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,5 +1,5 @@
 class PagesController < ApplicationController
-  skip_before_action :authenticate_user!, only: [ :home ]
+  skip_before_action :authenticate_user!, only: [:home]
   def show
     @service = Service.find(params[:id])
     @booking = Booking.new
@@ -29,5 +29,5 @@ class PagesController < ApplicationController
       @services = Service.all
     end
   end
-  
+
 end

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -1,5 +1,6 @@
 class ServicesController < ApplicationController
-  skip_before_action :authenticate_user!, only: [:show]
+  skip_before_action :authenticate_user!, only: %i[show]
+
   def show
     @service = Service.find(params[:id])
     @booking = Booking.new

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -1,4 +1,5 @@
 class ServicesController < ApplicationController
+  skip_before_action :authenticate_user!, only: [:show]
   def show
     @service = Service.find(params[:id])
     @booking = Booking.new


### PR DESCRIPTION
### Skipped requirement to be logged in order to see `services#show` page.
- This means everyone can view a service

### The next steps for `services#show`:
- Needs to be reworked for Desktop view
  - Plenty of work for us to keep our keyboards busy :) 
-------------------------------------------------------------------------------------------------------------------------
After we polish `services#show`, we should also allow `services#index` to be accessible to everyone.

See image below for current state:
![image](https://user-images.githubusercontent.com/105768950/191480915-69484a41-885d-4b73-810b-9875c8a0061d.png)
