### PR TITLE
Update service#show page

### DIFF
--- a/app/assets/stylesheets/components/_button.scss
+++ b/app/assets/stylesheets/components/_button.scss
@@ -18,7 +18,13 @@
   height: 5vh;
   font-weight: bold;
   font-size: 16px;
-  margin: 0.5rem 0
+  margin: 0.5rem 0;
+
+  &:hover {
+    background-color: #d5406096;
+    color: #ffffff;
+    transition: 0.1s;
+  }
 }
 
 .button-wide-alt {

--- a/app/assets/stylesheets/pages/_show.scss
+++ b/app/assets/stylesheets/pages/_show.scss
@@ -20,6 +20,12 @@
 
 .description {
   font-weight: bold;
-
   // #more {display: none;}
+}
+
+.carousel-img > * {
+  height: 48vh;
+  width: 100%;
+  object-fit: contain;
+  background-color: black;
 }

--- a/app/views/services/show.html.erb
+++ b/app/views/services/show.html.erb
@@ -1,10 +1,39 @@
-<%= render 'shared/navbar_back_pages' %>
-<!-- Hero Image Section Start-->
-<%= render 'image_carousel' %>
-
 <!-- Main section-->
 <div class="container px-3">
-  <div class="col-lg-8">
+  <div class="col-lg-12">
+<!-- Hero Image Section Start-->
+<div id="service-gallery" class="carousel slide" data-ride="carousel">
+  <ol class="carousel-indicators">
+    <li data-target="#service-gallery" data-slide-to="0" class="active"></li>
+    <li data-target="#service-gallery" data-slide-to="1"></li>
+    <li data-target="#service-gallery" data-slide-to="2"></li>
+  </ol>
+
+  <div class="carousel-inner">
+    <div class="carousel-item active">
+      <% if @service.photos.any? %>
+        <div class="d-block w-100"></div><%=cl_image_tag @service.photos.first.key, crop: :fill %>
+      <% end %>
+    </div>
+
+   <% @service.photos.drop(1).each do |photo| %>
+      <div class="carousel-item">
+        <div class="d-block w-100"><%= cl_image_tag photo.key, crop: :fill %></div>
+      </div>
+    <% end %>
+  </div>
+
+  <a class="carousel-control-prev" href="#service-gallery" role="button" data-slide="prev">
+    <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+    <span class="sr-only">Previous</span>
+  </a>
+
+  <a class="carousel-control-next" href="#service-gallery" role="button" data-slide="next">
+    <span class="carousel-control-next-icon" aria-hidden="true"></span>
+    <span class="sr-only">Next</span>
+  </a>
+</div>
+
 
     <!-- Description-head Start-->
     <div class="service-head">
@@ -34,7 +63,7 @@
     </div>
     <h3 class="h3-allivu description mb-3">Description</h3>
     <p class="p-allivu"><%= @service.description %></p>
-    
+
 
     <!-- Location start-->
     <h3 class="h3-allivu my-5"><strong>Location</strong></h3>
@@ -126,8 +155,10 @@
 
   <!-- Contact start-->
   <%= simple_form_for(@chatroom) do |f| %>
-          <%= f.hidden_field :name, value: @service.name %>
-          <%= f.submit class: "button-33", value: "Contact #{@service.user.first_name.capitalize}" %>
+    <%= f.hidden_field :name, value: @service.name %>
+    <div class="d-flex flex-column align-items-center">
+    <%= f.submit class: "button-33", value: "Contact #{@service.user.first_name.capitalize}" %>
+    </div>
   <% end %>
   <!-- Contact end-->
       </div>

--- a/app/views/services/show.html.erb
+++ b/app/views/services/show.html.erb
@@ -12,13 +12,13 @@
   <div class="carousel-inner">
     <div class="carousel-item active">
       <% if @service.photos.any? %>
-        <div class="d-block w-100"></div><%=cl_image_tag @service.photos.first.key, crop: :fill %>
+        <div class="carousel-img d-block"><%=cl_image_tag @service.photos.first.key %></div>
       <% end %>
     </div>
 
    <% @service.photos.drop(1).each do |photo| %>
       <div class="carousel-item">
-        <div class="d-block w-100"><%= cl_image_tag photo.key, crop: :fill %></div>
+        <div class="carousel-img d-block"><%= cl_image_tag photo.key %></div>
       </div>
     <% end %>
   </div>


### PR DESCRIPTION
### Partially fixed misaligned sections 
- Removed height/width on image
- Adjusted grid columns
- Centered contact button at the bottom of the page

**Will most likely continue to refine this page sometime this week.

### 26/09

**HEROKU:**
![Screenshot 2022-09-26 at 7 38 34 PM](https://user-images.githubusercontent.com/105768950/192344355-a92d56b8-36fa-435e-9093-7e9ed839543e.png)

**This pull request:**
![Screenshot 2022-09-26 at 7 38 36 PM](https://user-images.githubusercontent.com/105768950/192344360-b20b3f1f-8844-4021-a6f7-2286dbf6cddd.png)

**HEROKU:**
![Screenshot 2022-09-26 at 7 38 54 PM](https://user-images.githubusercontent.com/105768950/192344379-db559d85-ce27-41d7-8472-fda8fca14572.png)

**This pull request:**

![Screenshot 2022-09-26 at 7 38 57 PM](https://user-images.githubusercontent.com/105768950/192344382-a1873d2c-fc4c-43fd-8abb-54346a09b034.png)
------------------------------------------------------------------------------------------------------------------------
### Update: 27/09 Centered #show images in desktop view
- The dimensions of some images are in portrait, which makes it difficult to find the best solution to either fill/crop/cover.
- I went through Cloudinary's documentation and after experimenting figured it was best to modify the dimensions of the divs in CSS 
- I set a specified dimension and added a background color of black.
- Also changed the Big button to change color when in :hover state

**This pull request**
![Screenshot 2022-09-27 at 6 22 21 PM](https://user-images.githubusercontent.com/105768950/192581482-ee76dc5d-da14-4b83-8e9a-10fabd349dbd.png)
**This pull request**
![Screenshot 2022-09-27 at 6 22 36 PM](https://user-images.githubusercontent.com/105768950/192581496-789ef5a2-b939-4a4b-a68f-3c6efb0ffe50.png)

